### PR TITLE
Wrong naming of circuit updated

### DIFF
--- a/intermediate/The BB84 Quantum Cryptography algorithm.ipynb
+++ b/intermediate/The BB84 Quantum Cryptography algorithm.ipynb
@@ -171,20 +171,20 @@
     "    # Sender prepares qubits\n",
     "    for i in range(len(basis)):\n",
     "        if state[i] == 1:\n",
-    "            bb84_circuit.x(i)\n",
+    "            circuit.x(i)\n",
     "        if basis[i] == 1:\n",
-    "            bb84_circuit.h(i)\n",
+    "            circuit.h(i)\n",
     "   \n",
     "\n",
     "    # Measuring action performed by Bob\n",
     "    for i in range(len(measurement_basis)):\n",
     "        if measurement_basis[i] == 1:\n",
-    "            bb84_circuit.h(i)\n",
+    "            circuit.h(i)\n",
     "\n",
     "       \n",
-    "    bb84_circuit.measure_all()\n",
+    "    circuit.measure_all()\n",
     "    \n",
-    "    return bb84_circuit"
+    "    return circuit"
    ]
   },
   {


### PR DESCRIPTION
Causes the CNOT and Hadamard gates to not be recognised. Fixed naming.